### PR TITLE
Add wip macos support

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,9 +227,9 @@
                         </div>
                         <ul class="menu">
                             <!--If you change anything here make sure to change the name in main.js-->
-                            <li>Boot Timestamps</li>
-                            <li>Coreboot Log</li>
-                            <li>Coreboot Extended Log</li>
+                            <li id="nomacos1">Boot Timestamps</li>
+                            <li id="nomacos2">Coreboot Log</li>
+                            <li id="nomacos3">Coreboot Extended Log</li>
                             <li>EC Console Log</li>
                             <li>Battery Info</li>
                             <li>EC Chip Info</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chrultrabook-windows-controller",
-  "version": "2.4.1",
+  "version": "2.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrultrabook-windows-controller",
-      "version": "2.4.1",
+      "version": "2.4.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@tauri-apps/api": "^1.5.0",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -98,7 +98,7 @@ async fn close_splashscreen(window: Window) {
 #[tauri::command]
 async fn check_os() -> String {
     use std::env;
-    return env::consts::OS
+    return env::consts::OS.to_string();
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ use sysinfo::{CpuExt, System, SystemExt};
 use tauri::{CustomMenuItem, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem};
 use tauri::{Manager, Window};
 use tauri_plugin_autostart::MacosLauncher;
+use std::env;
 
 #[cfg(target_os = "linux")]
 const EC: &str = "ectool";
@@ -97,7 +98,6 @@ async fn close_splashscreen(window: Window) {
 
 #[tauri::command]
 async fn check_os() -> String {
-    use std::env;
     return env::consts::OS.to_string();
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             close_splashscreen,
-            is_windows,
+            check_os,
             get_cpu_usage,
             get_cpu_temp,
             get_ram_usage,
@@ -96,8 +96,9 @@ async fn close_splashscreen(window: Window) {
 }
 
 #[tauri::command]
-async fn is_windows() -> bool {
-    return os_info::get().os_type() == os_info::Type::Windows;
+async fn check_os() -> String {
+    use std::env;
+    return env::consts::OS
 }
 
 #[tauri::command]

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ const startHidden = document.getElementById("startHiddenInput");
 const startOnBoot = document.getElementById("startOnBootInput");
 
 //hides things currently incopatiable with linux and macos
-if ((check_os !== "windows")) {
+if (os !== "windows") {
   document.getElementById("startOnBoot").style.display = "none";
   document.getElementById("startHidden").style.display = "none";
   document.getElementById("startOnBootButton").style.display = "none";

--- a/src/main.js
+++ b/src/main.js
@@ -11,31 +11,29 @@ Chart.register(...registerables);
 document.addEventListener("contextmenu", (event) => event.preventDefault());
 
 //checks what os the user is on
-let os;
-setTimeout(async () => {
-  os = await invoke("check_os");
-});
+(async () => {
+  let os = await invoke("check_os");
+  //hides things currently incopatiable with linux and macos
+  if (os !== "windows") {
+    document.getElementById("startOnBoot").style.display = "none";
+    document.getElementById("startHidden").style.display = "none";
+    document.getElementById("startOnBootButton").style.display = "none";
+    document.getElementById("startHiddenButton").style.display = "none";
+  }
+  if (os === "macos") {
+    document.getElementById("biosVersion").style.display = "none";
+    document.getElementById("boardname").style.display = "none";
+    document.getElementById("nomacos1").remove();
+    document.getElementById("nomacos2").remove();
+    document.getElementById("nomacos3").remove();
+  }
+})();
 
 //settings menu
 const startupFan = document.getElementById("startupFansInput");
 const systemTray = document.getElementById("systemTrayInput");
 const startHidden = document.getElementById("startHiddenInput");
 const startOnBoot = document.getElementById("startOnBootInput");
-
-//hides things currently incopatiable with linux and macos
-if (os !== "windows") {
-  document.getElementById("startOnBoot").style.display = "none";
-  document.getElementById("startHidden").style.display = "none";
-  document.getElementById("startOnBootButton").style.display = "none";
-  document.getElementById("startHiddenButton").style.display = "none";
-}
-if(os === "macos"){
-    document.getElementById("biosVersion").style.display = "none";
-    document.getElementById("boardname").style.display = "none";
-    document.getElementById("nomacos1").style.display = "none";
-    document.getElementById("nomacos2").style.display = "none";
-    document.getElementById("nomacos3").style.display = "none";
-  }
 
 //start Hidden
 const hideOnStart = localStorage.getItem("startHidden");
@@ -553,13 +551,3 @@ if ((is_windows = true)) {
     startOnBoot.checked = true; //TODO: Error: unresolved
   }
 }
-
-
-
-
-
-
-
-
-
-console.log(os);

--- a/src/main.js
+++ b/src/main.js
@@ -553,3 +553,13 @@ if ((is_windows = true)) {
     startOnBoot.checked = true; //TODO: Error: unresolved
   }
 }
+
+
+
+
+
+
+
+
+
+console.log(os);

--- a/src/main.js
+++ b/src/main.js
@@ -11,9 +11,9 @@ Chart.register(...registerables);
 document.addEventListener("contextmenu", (event) => event.preventDefault());
 
 //checks what os the user is on
-let is_windows;
+let os;
 setTimeout(async () => {
-  is_windows = await invoke("is_windows");
+  os = await invoke("check_os");
 });
 
 //settings menu
@@ -23,12 +23,19 @@ const startHidden = document.getElementById("startHiddenInput");
 const startOnBoot = document.getElementById("startOnBootInput");
 
 //hides things currently incopatiable with linux and macos
-if ((is_windows = false)) {
+if ((check_os !== "windows")) {
   document.getElementById("startOnBoot").style.display = "none";
   document.getElementById("startHidden").style.display = "none";
   document.getElementById("startOnBootButton").style.display = "none";
   document.getElementById("startHiddenButton").style.display = "none";
 }
+if(os === "macos"){
+    document.getElementById("biosVersion").style.display = "none";
+    document.getElementById("boardname").style.display = "none";
+    document.getElementById("nomacos1").style.display = "none";
+    document.getElementById("nomacos2").style.display = "none";
+    document.getElementById("nomacos3").style.display = "none";
+  }
 
 //start Hidden
 const hideOnStart = localStorage.getItem("startHidden");

--- a/vite.config.js.timestamp-1698327136900-9818aacf71e81.mjs
+++ b/vite.config.js.timestamp-1698327136900-9818aacf71e81.mjs
@@ -1,0 +1,25 @@
+// vite.config.js
+import { defineConfig } from "file:///Users/ethan/Documents/GitHub/Chrultrabook-Controller/node_modules/vite/dist/node/index.js";
+import vue from "file:///Users/ethan/Documents/GitHub/Chrultrabook-Controller/node_modules/@vitejs/plugin-vue/dist/index.mjs";
+var vite_config_default = defineConfig(async () => ({
+  plugins: [vue()],
+  build: {
+    target: "esnext"
+  },
+  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+  //
+  // 1. prevent vite from obscuring rust errors
+  clearScreen: false,
+  // 2. tauri expects a fixed port, fail if that port is not available
+  server: {
+    port: 1420,
+    strictPort: true
+  },
+  // 3. to make use of `TAURI_DEBUG` and other env variables
+  // https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
+  envPrefix: ["VITE_", "TAURI_"]
+}));
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvVXNlcnMvZXRoYW4vRG9jdW1lbnRzL0dpdEh1Yi9DaHJ1bHRyYWJvb2stQ29udHJvbGxlclwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL1VzZXJzL2V0aGFuL0RvY3VtZW50cy9HaXRIdWIvQ2hydWx0cmFib29rLUNvbnRyb2xsZXIvdml0ZS5jb25maWcuanNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL1VzZXJzL2V0aGFuL0RvY3VtZW50cy9HaXRIdWIvQ2hydWx0cmFib29rLUNvbnRyb2xsZXIvdml0ZS5jb25maWcuanNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tIFwidml0ZVwiO1xuaW1wb3J0IHZ1ZSBmcm9tIFwiQHZpdGVqcy9wbHVnaW4tdnVlXCI7XG5cbi8vIGh0dHBzOi8vdml0ZWpzLmRldi9jb25maWcvXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoYXN5bmMgKCkgPT4gKHtcbiAgcGx1Z2luczogW3Z1ZSgpXSxcblxuICBidWlsZDoge1xuICAgIHRhcmdldDogJ2VzbmV4dCdcbiAgfSxcblxuICAvLyBWaXRlIG9wdGlvbnMgdGFpbG9yZWQgZm9yIFRhdXJpIGRldmVsb3BtZW50IGFuZCBvbmx5IGFwcGxpZWQgaW4gYHRhdXJpIGRldmAgb3IgYHRhdXJpIGJ1aWxkYFxuICAvL1xuICAvLyAxLiBwcmV2ZW50IHZpdGUgZnJvbSBvYnNjdXJpbmcgcnVzdCBlcnJvcnNcbiAgY2xlYXJTY3JlZW46IGZhbHNlLFxuICAvLyAyLiB0YXVyaSBleHBlY3RzIGEgZml4ZWQgcG9ydCwgZmFpbCBpZiB0aGF0IHBvcnQgaXMgbm90IGF2YWlsYWJsZVxuICBzZXJ2ZXI6IHtcbiAgICBwb3J0OiAxNDIwLFxuICAgIHN0cmljdFBvcnQ6IHRydWUsXG4gIH0sXG4gIC8vIDMuIHRvIG1ha2UgdXNlIG9mIGBUQVVSSV9ERUJVR2AgYW5kIG90aGVyIGVudiB2YXJpYWJsZXNcbiAgLy8gaHR0cHM6Ly90YXVyaS5zdHVkaW8vdjEvYXBpL2NvbmZpZyNidWlsZGNvbmZpZy5iZWZvcmVkZXZjb21tYW5kXG4gIGVudlByZWZpeDogW1wiVklURV9cIiwgXCJUQVVSSV9cIl0sXG59KSk7XG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQWlWLFNBQVMsb0JBQW9CO0FBQzlXLE9BQU8sU0FBUztBQUdoQixJQUFPLHNCQUFRLGFBQWEsYUFBYTtBQUFBLEVBQ3ZDLFNBQVMsQ0FBQyxJQUFJLENBQUM7QUFBQSxFQUVmLE9BQU87QUFBQSxJQUNMLFFBQVE7QUFBQSxFQUNWO0FBQUE7QUFBQTtBQUFBO0FBQUEsRUFLQSxhQUFhO0FBQUE7QUFBQSxFQUViLFFBQVE7QUFBQSxJQUNOLE1BQU07QUFBQSxJQUNOLFlBQVk7QUFBQSxFQUNkO0FBQUE7QUFBQTtBQUFBLEVBR0EsV0FBVyxDQUFDLFNBQVMsUUFBUTtBQUMvQixFQUFFOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
Current restrictions

- No cbmem. If you try to pull a log, you will get the message `Not available on this platform`
- We don't (currently) have the ability to pull bios version/boardname, since everything is spoofed to look like apple.
- cpu usage seems to lock (does this happen on linux too?)

Other notes:

- Why does the `manufacturer` function return a string and not a boolean?
- Where/how do we package ectool?